### PR TITLE
fixed a recurring issue: The error handler of Future.then must return a value of the returned future's type

### DIFF
--- a/lib/newrelic_http_client.dart
+++ b/lib/newrelic_http_client.dart
@@ -224,6 +224,7 @@ class NewRelicHttpClientRequest extends HttpClientRequest {
       return response;
     }, onError: (dynamic err) {
       NewrelicMobile.instance.recordError(err, StackTrace.current);
+      Error.throwWithStackTrace(err, StackTrace.current);
     });
   }
 
@@ -285,6 +286,7 @@ class NewRelicHttpClientRequest extends HttpClientRequest {
             response, _httpClientRequest, this.timestamp, traceData),
         onError: (dynamic err) {
       NewrelicMobile.instance.recordError(err, StackTrace.current);
+      Error.throwWithStackTrace(err, StackTrace.current);
     });
   }
 
@@ -301,6 +303,7 @@ class NewRelicHttpClientRequest extends HttpClientRequest {
             _wrapResponse(response, _httpClientRequest, timestamp, traceData),
         onError: (dynamic err) {
       NewrelicMobile.instance.recordError(err, StackTrace.current);
+      Error.throwWithStackTrace(err, StackTrace.current);
     });
   }
 
@@ -580,6 +583,7 @@ class NewRelicHttpClientResponse extends HttpClientResponse {
       return _wrapResponse(response, request, timestamp, traceData);
     }, onError: (dynamic err) {
       NewrelicMobile.instance.recordError(err, StackTrace.current);
+      Error.throwWithStackTrace(err, StackTrace.current);
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: newrelic_mobile
 description: Flutter plugin for NewRelic Mobile. This plugin allows you to instrument Flutter apps with help of native New Relic Android and iOS agents.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/newrelic/newrelic-flutter-agent
 
 environment:


### PR DESCRIPTION
Since the value was not being returned from `onError` parameter inside `.then()`, we were getting a report of issue `Invalid argument(s) (onError): The error handler of Future.then must return a value of the returned future's type`. We fixed it by deliberately throwing error from those methods.
